### PR TITLE
FIX: use getOriginalDoc in originalDocChangeEffect

### DIFF
--- a/src/unified.ts
+++ b/src/unified.ts
@@ -79,7 +79,7 @@ export const updateOriginalDoc = StateEffect.define<{doc: Text, changes: ChangeS
 /// Create an effect that, when added to a transaction on a unified
 /// merge view, will update the original document that's being compared against.
 export function originalDocChangeEffect(state: EditorState, changes: ChangeSet): StateEffect<{doc: Text, changes: ChangeSet}> {
-  return updateOriginalDoc.of({doc: changes.apply(state.doc), changes})
+  return updateOriginalDoc.of({doc: changes.apply(getOriginalDoc(state)), changes})
 }
 
 const originalDoc = StateField.define<Text>({


### PR DESCRIPTION
This was causing a length mismatch error because the ChangeSet should be for the original. Believe this should fix it