### PR TITLE
FIX: Fix chunk expansion for insertions at end of document

### DIFF
--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -65,7 +65,8 @@ export class Chunk {
 
 function fromLine(fromA: number, fromB: number, a: Text, b: Text) {
   let lineA = a.lineAt(fromA), lineB = b.lineAt(fromB)
-  return lineA.to == fromA && lineB.to == fromB && fromA < a.length && fromB < b.length
+  return lineA.to == fromA && lineB.to == fromB &&
+    (fromA < a.length && fromB < b.length || lineA.from < fromA || lineB.from < fromB)
     ? [fromA + 1, fromB + 1] : [lineA.from, lineB.from]
 }
 

--- a/test/test-chunk.ts
+++ b/test/test-chunk.ts
@@ -35,6 +35,12 @@ describe("chunks", () => {
     ist([ch1.fromB, ch1.toB], [4, 5], byJSON)
   })
 
+  it("handles insertion at end of single-line document", () => {
+    let [ch1] = Chunk.build(Text.of(["hello"]), Text.of(["hello", "world"]))
+    ist([ch1.fromA, ch1.toA], [6, 6], byJSON)
+    ist([ch1.fromB, ch1.toB], [6, 12], byJSON)
+  })
+
   it("can update chunks for changes", () => {
     let stateA = EditorState.create({doc: docA}), stateB = EditorState.create({doc: docB})
     let chunks = Chunk.build(stateA.doc, stateB.doc)
@@ -56,8 +62,8 @@ describe("chunks", () => {
     let [, , ch3, , ch5] = chunks2
     ist([ch3.fromA, ch3.toA], [stateA.doc.line(601).from, stateA.doc.line(602).from], byJSON)
     ist([ch3.fromB, ch3.toB], [tr2.newDoc.line(600).from, tr2.newDoc.line(601).from], byJSON)
-    ist([ch5.fromA, ch5.toA], [stateA.doc.length - 9, stateA.doc.length + 1], byJSON)
-    ist([ch5.fromB, ch5.toB], [tr2.newDoc.length - 13, tr2.newDoc.length + 1], byJSON)
+    ist([ch5.fromA, ch5.toA], [stateA.doc.length + 1, stateA.doc.length + 1], byJSON)
+    ist([ch5.fromB, ch5.toB], [tr2.newDoc.length - 3, tr2.newDoc.length + 1], byJSON)
   })
 
   it("can handle deleting updates", () => {


### PR DESCRIPTION
When a change is a pure insertion at the end of a document (`fromA == a.length`), `fromLine` falls back to `[lineA.from, lineB.from]`, expanding the chunk to cover the entire last line. This causes the unified merge view to mark unchanged content as part of the diff.

## Reproduction

Diff `"hello"` against `"hello\nworld"` using `unifiedMergeView`. The entire first line `hello` is shown as both deleted and inserted, instead of `world` being a clean insertion.

```js
Chunk.build(Text.of(["hello"]), Text.of(["hello", "world"]))
// Before fix: chunk covers fromA=0 (entire first line pulled in)
// After fix: chunk covers fromA=6 (only the insertion)
```

## Fix

In `fromLine`, the condition `fromA < a.length && fromB < b.length` prevents advancing past the line end when either document has ended. But for insertions at document end, we should still advance if the position is at the **end** of a non-empty line (not the start of an empty trailing line).

The added check `lineA.from < fromA || lineB.from < fromB` distinguishes between:
- Position at the **end** of a line (`lineA.from < fromA`) → advance to next line
- Position at the **start** of an empty trailing line (`lineA.from == fromA`) → stay (existing behavior)